### PR TITLE
fix: should work with dora@0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,10 @@
     "babel-eslint": "^6.0.4",
     "babel-istanbul": "^0.5.9",
     "babel-plugin-add-module-exports": "~0.1.1",
+    "babel-plugin-transform-runtime": "^6.9.0",
     "babel-preset-es2015": "~6.1.18",
     "babel-preset-stage-0": "~6.1.18",
+    "babel-runtime": "^6.9.2",
     "coveralls": "^2.11.6",
     "dora": "0.3.x",
     "eslint": "~1.9.0",
@@ -46,7 +48,8 @@
       "stage-0"
     ],
     "plugins": [
-      "add-module-exports"
+      "add-module-exports",
+      "transform-runtime"
     ]
   },
   "files": [


### PR DESCRIPTION
See: https://github.com/dora-js/dora/issues/56

不然用户就需要自行引入 `babel-polyfill`。
